### PR TITLE
POP-2767 add coldown to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
     labels:
       - "kind/dependencies"
       - "bot"
@@ -11,6 +13,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
     versioning-strategy: "increase"
     allow:
       - dependency-type: "production"


### PR DESCRIPTION
Adding a cooldown of 7 days to the dependabot config to safeguard against supply-chain attacks.
